### PR TITLE
WIP: Update to `async`/`await`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ failure = "0.1"
 derive_more = "0.99"
 base64 = "0.11"
 uuid = {version = "0.8", features = ["serde", "v4"]}
-mqtt311 = { path = "../mqtt311/", version = "0.2.0" }
+mqtt311 = { git = "https://github.com/vivint-smarthome/mqtt311", branch = "update-deps", version = "0.2.0" }
 tokio-rustls = "0.12"
 tokio-util = { version = "0.2.0", features = ["codec"] }
 webpki = "0.21"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ license = "Unlicense"
 tokio = { version = "0.2.6", features = [ "io-util", "stream", "sync", "rt-threaded", "tcp", "time" ], default-features = false }
 bytes = "0.5"
 futures = "0.3.1"
-crossbeam-channel = "0.4"
 log = "0.4"
 failure = "0.1"
 derive_more = "0.99"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,22 +9,24 @@ edition = "2018"
 license = "Unlicense"
 
 [dependencies]
-tokio = { version = "0.1.21", features = [ "codec", "io", "rt-full", "tcp", "timer" ], default-features = false }
-bytes = "0.4"
-futures = "0.1.28"
-crossbeam-channel = "0.3"
+tokio = { version = "0.2.6", features = [ "io-util", "stream", "sync", "rt-threaded", "tcp", "time" ], default-features = false }
+bytes = "0.5"
+futures = "0.3.1"
+crossbeam-channel = "0.4"
 log = "0.4"
 failure = "0.1"
-derive_more = "0.13"
-base64 = "0.10"
-uuid = {version = "0.7", features = ["serde", "v4"]}
-mqtt311 = "0.2"
-tokio-rustls = ">=0.8, <=0.9"
-webpki = ">=0.8, <=0.19"
-
+derive_more = "0.99"
+base64 = "0.11"
+uuid = {version = "0.8", features = ["serde", "v4"]}
+mqtt311 = { path = "../mqtt311/", version = "0.2.0" }
+tokio-rustls = "0.12"
+tokio-util = { version = "0.2.0", features = ["codec"] }
+webpki = "0.21"
+rental = "0.5.5"
+stable_deref_trait = "1.1.1"
 
 [dependencies.jsonwebtoken]
-version = ">=5.0.1, <=6.0"
+version = "7.0.0-alpha.2"
 optional = true
 
 [dependencies.chrono]
@@ -39,10 +41,15 @@ optional = true
 version = "1"
 optional = true
 
+[target.'cfg(test)'.dependencies]
+tokio = { version = "0.2.6", features = [ "macros", "stream" ] }
+
 [dev-dependencies]
 envy = "0.3"
+futures = "0.3.1"
 serde = "1"
 serde_derive = "1"
+tokio = { version = "0.2.6", features = [ "macros" ], default-features = false }
 pretty_env_logger = "0.3"
 
 [features]

--- a/examples/genproxyauth.rs
+++ b/examples/genproxyauth.rs
@@ -9,7 +9,8 @@ struct Claims {
     aud: String,
 }
 
-fn main() {
+#[tokio::main]
+async fn main() {
     let key = include_bytes!("tlsfiles/server.key.pem");
     let time = Utc::now();
     let jwt_header = Header::new(Algorithm::RS256);

--- a/examples/keepalive.rs
+++ b/examples/keepalive.rs
@@ -1,26 +1,30 @@
-use rumqtt::{MqttClient, MqttOptions, ReconnectOptions, QoS};
-use std::thread;
+use futures::stream::StreamExt;
+use rumqtt::{MqttClient, MqttOptions, QoS, ReconnectOptions};
 use std::time::Duration;
+use tokio::time::delay_for;
 
-fn main() {
+#[tokio::main]
+async fn main() {
     pretty_env_logger::init();
     let reconnect_options = ReconnectOptions::Always(5);
     let mqtt_options = MqttOptions::new("test-id", "localhost", 1883)
         .set_keep_alive(10)
         .set_reconnect_opts(reconnect_options);
 
-    let (mut mqtt_client, notifications) = MqttClient::start(mqtt_options).unwrap();
-    thread::spawn(move || {
-        thread::sleep(Duration::from_secs(2));
+    let (mut mqtt_client, mut notifications) = MqttClient::start(mqtt_options).await.unwrap();
+    let thread = tokio::spawn(async move {
+        delay_for(Duration::from_secs(2)).await;
 
         mqtt_client
             .publish("hello/world", QoS::AtLeastOnce, true, "test")
+            .await
             .unwrap();
 
-        thread::sleep(Duration::from_secs(300));
+        delay_for(Duration::from_secs(300)).await;
     });
 
-    for notification in notifications {
+    while let Some(notification) = notifications.next().await {
         println!("{:?}", notification)
     }
+    thread.await.unwrap();
 }

--- a/examples/playpause.rs
+++ b/examples/playpause.rs
@@ -1,42 +1,47 @@
+use futures::stream::StreamExt;
 use rumqtt::{MqttClient, MqttOptions, QoS};
-use std::{thread, time::Duration};
+use std::time::Duration;
+use tokio::time::delay_for;
 
-fn main() {
+#[tokio::main]
+async fn main() {
     pretty_env_logger::init();
     let mqtt_options = MqttOptions::new("test-id", "127.0.0.1", 1883).set_keep_alive(10);
 
-    let (mut mqtt_client, notifications) = MqttClient::start(mqtt_options).unwrap();
+    let (mut mqtt_client, mut notifications) = MqttClient::start(mqtt_options).await.unwrap();
 
-    mqtt_client.subscribe("hello/world", QoS::AtLeastOnce).unwrap();
+    mqtt_client.subscribe("hello/world", QoS::AtLeastOnce).await.unwrap();
 
     let mut c1 = mqtt_client.clone();
     let mut c2 = mqtt_client.clone();
 
-    thread::spawn(move || {
+    let thread1 = tokio::spawn(async move {
         let dur = Duration::new(1, 0);
 
         for i in 0..100 {
             let payload = format!("publish {}", i);
-            thread::sleep(dur);
-            c1.publish("hello/world", QoS::AtLeastOnce, false, payload).unwrap();
+            delay_for(dur).await;
+            c1.publish("hello/world", QoS::AtLeastOnce, false, payload).await.unwrap();
         }
     });
 
-    thread::spawn(move || {
+    let thread2 = tokio::spawn(async move {
         let dur = Duration::new(5, 0);
 
         for i in 0..100 {
             if i % 2 == 0 {
-                c2.pause().unwrap();
+                c2.pause().await.unwrap();
             } else {
-                c2.resume().unwrap();
+                c2.resume().await.unwrap();
             }
 
-            thread::sleep(dur);
+            delay_for(dur).await;
         }
     });
 
-    for notification in notifications {
+    while let Some(notification) = notifications.next().await {
         println!("{:?}", notification)
     }
+    thread1.await.unwrap();
+    thread2.await.unwrap();
 }

--- a/examples/reconnection.rs
+++ b/examples/reconnection.rs
@@ -2,19 +2,23 @@ extern crate pretty_env_logger;
 extern crate rumqtt;
 //use rumqtt::{MqttClient, MqttOptions};
 //use std::thread;
+//use std::time::Duration;
+//use tokio::time::delay_for;
 
-fn main() {
+#[tokio::main]
+async fn main() {
     // pretty_env_logger::init();
     // let mqtt_options = MqttOptions::new("test-id-1", "localhost", 1883);
 
-    // let (mut mqtt_client, notifications) = MqttClient::start(mqtt_options);
+    // let (mut mqtt_client, mut notifications) = MqttClient::start(mqtt_options);
 
-    // thread::spawn(move || {
+    // tokio::spawn(async move {
     //     // let mqtt_options = MqttOptions::new("test-id-2", "localhost", 1883).set_keep_alive(120);
     //     // mqtt_client.reconnect(mqtt_options).unwrap();
     // });
 
-    // for notification in notifications {
+    // while let Some(notification) = notifications.next().await {
     //     println!("{:?}", notification)
     // }
+    // thread.await.unwrap();
 }

--- a/examples/shutdown.rs
+++ b/examples/shutdown.rs
@@ -1,31 +1,41 @@
+use futures::stream::StreamExt;
 use rumqtt::{MqttClient, MqttOptions, QoS};
-use std::{thread, time::Duration};
+use std::time::Duration;
+use tokio::time::delay_for;
 
-fn main() {
+#[tokio::main]
+async fn main() {
     pretty_env_logger::init();
     let mqtt_options = MqttOptions::new("test-id-1", "localhost", 1883).set_keep_alive(10);
 
-    let (mut mqtt_client, notifications) = MqttClient::start(mqtt_options).unwrap();
+    let (mut mqtt_client, mut notifications) = MqttClient::start(mqtt_options).await.unwrap();
 
-    thread::spawn(move || {
-        thread::sleep(Duration::from_secs(5));
+    let thread = tokio::spawn(async move {
+        delay_for(Duration::from_secs(5)).await;
 
         for i in 1..11 {
             let payload = format!("publish {}", i);
-            thread::sleep(Duration::from_millis(100));
-            mqtt_client.publish("hello/world", QoS::AtLeastOnce, false, payload).unwrap();
+            delay_for(Duration::from_millis(100)).await;
+            mqtt_client
+                .publish("hello/world", QoS::AtLeastOnce, false, payload)
+                .await
+                .unwrap();
         }
 
-        mqtt_client.shutdown().unwrap();
+        mqtt_client.shutdown().await.unwrap();
 
         for i in 11..21 {
             let payload = format!("publish {}", i);
-            thread::sleep(Duration::from_millis(100));
-            mqtt_client.publish("hello/world", QoS::AtLeastOnce, false, payload).unwrap();
+            delay_for(Duration::from_millis(100)).await;
+            mqtt_client
+                .publish("hello/world", QoS::AtLeastOnce, false, payload)
+                .await
+                .unwrap();
         }
     });
 
-    for notification in notifications {
+    while let Some(notification) = notifications.next().await {
         println!("{:?}", notification)
     }
+    thread.await.unwrap();
 }

--- a/examples/tls.rs
+++ b/examples/tls.rs
@@ -1,7 +1,10 @@
+use futures::stream::StreamExt;
 use rumqtt::{MqttClient, MqttOptions, QoS};
-use std::{thread, time::Duration};
+use std::time::Duration;
+use tokio::time::delay_for;
 
-fn main() {
+#[tokio::main]
+async fn main() {
     pretty_env_logger::init();
 
     let client_id = "tls-test".to_owned();
@@ -9,24 +12,27 @@ fn main() {
     let client_cert = include_bytes!("tlsfiles/bike1.cert.pem").to_vec();
     let client_key = include_bytes!("tlsfiles/bike1.key.pem").to_vec();
 
-
     let mqtt_options = MqttOptions::new(client_id, "localhost", 8883)
         .set_ca(ca)
         .set_client_auth(client_cert, client_key)
         .set_keep_alive(10);
 
-    let (mut mqtt_client, notifications) = MqttClient::start(mqtt_options).unwrap();
+    let (mut mqtt_client, mut notifications) = MqttClient::start(mqtt_options).await.unwrap();
     let topic = "hello/world";
 
-    thread::spawn(move || {
+    let thread = tokio::spawn(async move {
         for i in 0..100 {
             let payload = format!("publish {}", i);
-            thread::sleep(Duration::from_secs(1));
-            mqtt_client.publish(topic.clone(), QoS::AtLeastOnce, false, payload).unwrap();
+            delay_for(Duration::from_secs(1)).await;
+            mqtt_client
+                .publish(topic.clone(), QoS::AtLeastOnce, false, payload)
+                .await
+                .unwrap();
         }
     });
 
-    for notification in notifications {
+    while let Some(notification) = notifications.next().await {
         println!("{:?}", notification)
     }
+    thread.await.unwrap();
 }

--- a/src/client/connection.rs
+++ b/src/client/connection.rs
@@ -361,7 +361,7 @@ impl Connection {
         }
     }
 
-    /// Handles all incoming network packets (including sending notifications to user over crossbeam
+    /// Handles all incoming network packets (including sending notifications to user over a
     /// channel) and creates a stream of packets to send on network
     async fn network_reply_stream(
         &self,

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -80,7 +80,7 @@ pub struct MqttClient {
 
 impl MqttClient {
     /// Starts a new mqtt connection in a thread and returns [mqttclient]
-    /// instance to send requests/commands to the event loop and a crossbeam
+    /// instance to send requests/commands to the event loop and a
     /// channel receiver to receive notifications sent by the event loop.
     ///
     /// See `select.rs` example
@@ -123,11 +123,9 @@ impl MqttClient {
             payload: Arc::new(payload),
         };
 
-        let tx = &mut self.request_tx;
-        tx.send(Request::Publish(publish))
+        self.request_tx.send(Request::Publish(publish))
             .await
-            .map_err(ClientError::MpscRequestSend)?;
-        Ok(())
+            .map_err(ClientError::MpscRequestSend)
     }
 
     /// Requests the eventloop for mqtt subscribe
@@ -144,11 +142,9 @@ impl MqttClient {
             topics: vec![topic],
         };
 
-        let tx = &mut self.request_tx;
-        tx.send(Request::Subscribe(subscribe))
+        self.request_tx.send(Request::Subscribe(subscribe))
             .await
-            .map_err(ClientError::MpscRequestSend)?;
-        Ok(())
+            .map_err(ClientError::MpscRequestSend)
     }
 
     /// Requests the eventloop for mqtt unsubscribe

--- a/src/client/mqttstate.rs
+++ b/src/client/mqttstate.rs
@@ -392,7 +392,7 @@ fn connect_packet(mqttoptions: &MqttOptions) -> Result<Connect, ConnectError> {
 fn gen_iotcore_password(project: String, key: &[u8], expiry: i64) -> Result<String, ConnectError> {
     //TODO: Remove chrono for current utc timestamp and use something in standard library
     use chrono::Utc;
-    use jsonwebtoken::{encode, Algorithm, Header};
+    use jsonwebtoken::{encode, Algorithm, Header, EncodingKey};
     use serde_derive::{Deserialize, Serialize};
 
     #[derive(Debug, Serialize, Deserialize)]
@@ -412,7 +412,7 @@ fn gen_iotcore_password(project: String, key: &[u8], expiry: i64) -> Result<Stri
 
     let claims = Claims { iat, exp, aud: project };
 
-    Ok(encode(&jwt_header, &claims, &key)?)
+    Ok(encode(&jwt_header, &claims, &EncodingKey::from_secret(&key))?)
 }
 
 #[cfg(test)]

--- a/src/client/mqttstate.rs
+++ b/src/client/mqttstate.rs
@@ -1,13 +1,11 @@
-use std::{
-    collections::VecDeque,
-    result::Result,
-    time::Instant,
-};
+use std::{collections::VecDeque, result::Result, time::Instant};
 
-use crate::client::{Notification, Request};
-use crate::error::{ConnectError, NetworkError};
-use crate::mqttoptions::{MqttOptions, SecurityOptions};
-use mqtt311::{Connack, Connect, ConnectReturnCode, Packet, PacketIdentifier, Publish, QoS, Subscribe, Protocol};
+use crate::{
+    client::{Notification, Request},
+    error::{ConnectError, NetworkError},
+    mqttoptions::{MqttOptions, SecurityOptions},
+};
+use mqtt311::{Connack, Connect, ConnectReturnCode, Packet, PacketIdentifier, Protocol, Publish, QoS, Subscribe};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MqttConnectionStatus {
@@ -84,7 +82,6 @@ impl MqttState {
     // E.g For incoming QoS1 publish packet, this method returns (Publish, Puback). Publish packet will
     // be forwarded to user and Pubck packet will be written to network
     pub fn handle_incoming_mqtt_packet(&mut self, packet: Packet) -> Result<(Notification, Request), NetworkError> {
-
         let out = match packet {
             Packet::Pingresp => self.handle_incoming_pingresp(),
             // TODO: Remove this with async await. This is just to satisfy combinator rules during timeout
@@ -151,13 +148,17 @@ impl MqttState {
     /// Sets next packet id if pkid is None (fresh publish) and adds it to the
     /// outgoing publish queue
     pub fn handle_outgoing_publish(&mut self, publish: Publish) -> Result<Publish, NetworkError> {
-        
         let publish = match publish.qos {
             QoS::AtMostOnce => publish,
             QoS::AtLeastOnce | QoS::ExactlyOnce => self.add_packet_id_and_save(publish),
         };
 
-        debug!("Publish. Topic = {:?}, Pkid = {:?}, Payload Size = {:?}", publish.topic_name, publish.pkid, publish.payload.len());
+        debug!(
+            "Publish. Topic = {:?}, Pkid = {:?}, Payload Size = {:?}",
+            publish.topic_name,
+            publish.pkid,
+            publish.payload.len()
+        );
         Ok(publish)
     }
 
@@ -168,10 +169,9 @@ impl MqttState {
     pub fn is_disconnecting(&self) -> bool {
         match self.connection_status {
             MqttConnectionStatus::Disconnecting => true,
-            _ => false
+            _ => false,
         }
     }
-
 
     pub fn handle_incoming_puback(&mut self, pkid: PacketIdentifier) -> Result<(Notification, Request), NetworkError> {
         match self.outgoing_pub.iter().position(|x| x.pkid == Some(pkid)) {
@@ -294,7 +294,6 @@ impl MqttState {
             return Err(NetworkError::AwaitPingResp);
         }
 
-
         let ping = if elapsed_in > keep_alive || elapsed_out > keep_alive {
             self.await_pingresp = true;
             true
@@ -306,7 +305,11 @@ impl MqttState {
             "Ping = {:?}. keep alive = {},
             last incoming packet before {} millisecs,
             last outgoing packet before {} millisecs",
-            ping, keep_alive.as_millis(), elapsed_in.as_millis(), elapsed_out.as_millis());
+            ping,
+            keep_alive.as_millis(),
+            elapsed_in.as_millis(),
+            elapsed_out.as_millis()
+        );
 
         Ok(ping)
     }
@@ -320,11 +323,14 @@ impl MqttState {
         Ok((Notification::None, Request::None))
     }
 
-    pub fn handle_outgoing_subscribe(&mut self, mut subscription: Subscribe) -> Result<Subscribe, NetworkError> {        
+    pub fn handle_outgoing_subscribe(&mut self, mut subscription: Subscribe) -> Result<Subscribe, NetworkError> {
         let pkid = self.next_pkid();
         subscription.pkid = pkid;
 
-        debug!("Subscribe. Topics = {:?}, Pkid = {:?}", subscription.topics, subscription.pkid);
+        debug!(
+            "Subscribe. Topics = {:?}, Pkid = {:?}",
+            subscription.topics, subscription.pkid
+        );
         Ok(subscription)
     }
 
@@ -414,9 +420,11 @@ mod test {
     use std::{sync::Arc, thread, time::Duration};
 
     use super::{MqttConnectionStatus, MqttState};
-    use crate::client::{Notification, Request};
-    use crate::error::NetworkError;
-    use crate::mqttoptions::MqttOptions;
+    use crate::{
+        client::{Notification, Request},
+        error::NetworkError,
+        mqttoptions::MqttOptions,
+    };
     use mqtt311::*;
 
     fn build_outgoing_publish(qos: QoS) -> Publish {
@@ -640,9 +648,9 @@ mod test {
         thread::sleep(Duration::from_secs(10));
 
         // should ping
-         match  mqtt.handle_outgoing_ping().unwrap() {
+        match mqtt.handle_outgoing_ping().unwrap() {
             true => (),
-            _ => assert!(false, "expecting ping")
+            _ => assert!(false, "expecting ping"),
         }
 
         // network activity other than pingresp
@@ -670,17 +678,17 @@ mod test {
         thread::sleep(Duration::from_secs(10));
 
         // should ping
-        match  mqtt.handle_outgoing_ping().unwrap() {
+        match mqtt.handle_outgoing_ping().unwrap() {
             true => (),
-            _ => assert!(false, "expecting ping")
+            _ => assert!(false, "expecting ping"),
         }
         mqtt.handle_incoming_mqtt_packet(Packet::Pingresp).unwrap();
 
         thread::sleep(Duration::from_secs(10));
         // should ping
-         match  mqtt.handle_outgoing_ping().unwrap() {
+        match mqtt.handle_outgoing_ping().unwrap() {
             true => (),
-            _ => assert!(false, "expecting ping")
+            _ => assert!(false, "expecting ping"),
         }
     }
 

--- a/src/client/network.rs
+++ b/src/client/network.rs
@@ -215,7 +215,7 @@ fn resolve(host: &str, port: u16) -> Result<SocketAddr, io::Error> {
 
 fn generate_httpproxy_auth(id: &str, key: &[u8], expiry: i64) -> String {
     use chrono::{Duration, Utc};
-    use jsonwebtoken::{encode, Algorithm, Header};
+    use jsonwebtoken::{encode, Algorithm, Header, EncodingKey};
     use uuid::Uuid;
 
     #[derive(Debug, Serialize, Deserialize)]
@@ -237,7 +237,7 @@ fn generate_httpproxy_auth(id: &str, key: &[u8], expiry: i64) -> String {
 
     let claims = Claims { iat, exp, jti };
 
-    let jwt = encode(&jwt_header, &claims, &key).unwrap();
+    let jwt = encode(&jwt_header, &claims, &EncodingKey::from_secret(&key)).unwrap();
     let userid_password = format!("{}:{}", id, jwt);
     let auth = base64::encode(userid_password.as_bytes());
 

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -1,9 +1,9 @@
 //! Codec to convert incoming bytes of a tcp stream into mqtt packets
 //! and outgoing mqtt packets to raw bytes
-use bytes::BytesMut;
+use bytes::{Buf, BytesMut};
 use mqtt311::{self, MqttRead, MqttWrite, Packet};
 use std::io::{self, Cursor, ErrorKind};
-use tokio::codec::{Decoder, Encoder};
+use tokio_util::codec::{Decoder, Encoder};
 
 /// Mqtt codec
 #[derive(Debug)]
@@ -56,7 +56,7 @@ impl Decoder for MqttCodec {
         // println!("buf = {:?}", buf);
         // println!("{:?}, {:?}, {:?}", len, packet, buf.len());
 
-        buf.split_to(len);
+        buf.advance(len);
 
         Ok(Some(packet))
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,101 +11,112 @@
 //!   as password to authenticate the client
 //! * Inbuilt support fot throttling (Saas IOT providers usually impose rate limiting)
 //! * Http `connect` support to tunnel mqtt data through http proxy servers
-//! 
+//!
 //! ## Publish and subscribe
 //! ```no_run
+//! use futures::stream::StreamExt;
 //! use rumqtt::{MqttClient, MqttOptions, QoS};
-//! use std::{thread, time::Duration};
+//! use std::time::Duration;
+//! use tokio::{spawn, time::delay_for};
 //!
-//! fn main() {
+//! #[tokio::main]
+//! async fn main() {
 //!     let mqtt_options = MqttOptions::new("test-pubsub1", "localhost", 1883);
-//!     let (mut mqtt_client, notifications) = MqttClient::start(mqtt_options).unwrap();
-//!      
-//!     mqtt_client.subscribe("hello/world", QoS::AtLeastOnce).unwrap();
+//!     let (mut mqtt_client, mut notifications) = MqttClient::start(mqtt_options).await.unwrap();
+//!
+//!     mqtt_client.subscribe("hello/world", QoS::AtLeastOnce).await.unwrap();
 //!     let sleep_time = Duration::from_secs(1);
-//!     thread::spawn(move || {
+//!     spawn(async move {
 //!         for i in 0..100 {
 //!             let payload = format!("publish {}", i);
-//!             thread::sleep(sleep_time);
-//!             mqtt_client.publish("hello/world", QoS::AtLeastOnce, false, payload).unwrap();
+//!             delay_for(sleep_time).await;
+//!             mqtt_client.publish("hello/world", QoS::AtLeastOnce, false, payload).await.unwrap();
 //!         }
 //!     });
 //!
-//!     for notification in notifications {
+//!     while let Some(notification) = notifications.next().await {
 //!         println!("{:?}", notification)
 //!     }
 //! }
 //! ```
-//! 
-//! 
+//!
+//!
 //! ## Select on incoming notifications using crossbeam select!
 //! ```no_run
+//! use futures::{channel::oneshot, select, FutureExt, StreamExt};
 //! use rumqtt::{MqttClient, MqttOptions, QoS};
-//! use std::{thread, time::Duration};
-//! use crossbeam_channel::select;
+//! use std::time::Duration;
+//! use tokio::{spawn, time::delay_for};
 //!
-//! fn main() {
+//! #[tokio::main]
+//! async fn main() {
 //!     let mqtt_options = MqttOptions::new("test-pubsub1", "localhost", 1883);
-//!     let (mut mqtt_client, notifications) = MqttClient::start(mqtt_options).unwrap();
-//!     let (done_tx, done_rx) = crossbeam_channel::bounded(1);
-//! 
-//!     mqtt_client.subscribe("hello/world", QoS::AtLeastOnce).unwrap();
+//!     let (mut mqtt_client, mut notifications) = MqttClient::start(mqtt_options).await.unwrap();
+//!     let (done_tx, done_rx) = oneshot::channel();
+//!
+//!     mqtt_client.subscribe("hello/world", QoS::AtLeastOnce).await.unwrap();
 //!     let sleep_time = Duration::from_secs(1);
-//!     thread::spawn(move || {
+//!     spawn(async move {
 //!         for i in 0..100 {
 //!             let payload = format!("publish {}", i);
-//!             thread::sleep(sleep_time);
-//!             mqtt_client.publish("hello/world", QoS::AtLeastOnce, false, payload).unwrap();
+//!             delay_for(sleep_time).await;
+//!             mqtt_client.publish("hello/world", QoS::AtLeastOnce, false, payload).await.unwrap();
 //!         }
-//!         
-//!         thread::sleep(sleep_time * 10);
-//!         done_tx.send(true).unwrap();
+//!
+//!         delay_for(sleep_time * 10).await;
+//!         done_tx.send(()).unwrap();
 //!     });
 //!
 //!     // select between mqtt notifications and other channel rx
+//!     let mut done_rx = done_rx.fuse();
 //!     loop {
 //!         select! {
-//!             recv(notifications) -> notification => {
+//!             notification = notifications.next() => {
 //!                 println!("{:?}", notification)
 //!             }
-//!             recv(done_rx) -> _done => break
+//!             res = done_rx => {
+//!                 let () = res.unwrap();
+//!             }
 //!         }
 //!     }
 //! }
 //! ```
-//! 
+//!
 //! ## Clone the client to access mqtt eventloop from different threads
 //! ```no_run
+//! use futures::stream::StreamExt;
 //! use rumqtt::{MqttClient, MqttOptions, QoS};
-//! use std::{thread, time::Duration};
+//! use std::time::Duration;
+//! use tokio::{spawn, time::delay_for};
 //!
-//! fn main() {
+//! #[tokio::main]
+//! async fn main() {
 //!     let mqtt_options = MqttOptions::new("test-pubsub1", "localhost", 1883);
-//!     let (mut mqtt_client, notifications) = MqttClient::start(mqtt_options).unwrap();
+//!     let (mut mqtt_client, mut notifications) = MqttClient::start(mqtt_options).await.unwrap();
 //!     let mut c1 = mqtt_client.clone();
 //!     let mut c2 = mqtt_client.clone();
-//!     
-//!     mqtt_client.subscribe("hello/world", QoS::AtLeastOnce).unwrap();
+//!
+//!     mqtt_client.subscribe("hello/world", QoS::AtLeastOnce).await.unwrap();
 //!     let sleep_time = Duration::from_secs(1);
-//!     thread::spawn(move || {
+//!     spawn(async move {
 //!         for i in 0..100 {
 //!             let payload = format!("publish {}", i);
-//!             thread::sleep(sleep_time);
-//!             c1.publish("hello/world", QoS::AtLeastOnce, false, payload).unwrap();
+//!             delay_for(sleep_time).await;
+//!             c1.publish("hello/world", QoS::AtLeastOnce, false, payload).await.unwrap();
 //!         }
 //!     });
-//! 
+//!
 //!     // pause and resume network from this thread
-//!     thread::spawn(move || {
+//!     spawn(async move {
 //!         let dur = Duration::new(5, 0);
 //!         for i in 0..100 {
-//!             if i % 2 == 0 { c2.pause().unwrap() } else { c2.resume().unwrap() }
-//!             thread::sleep(dur);
+//!             if i % 2 == 0 { c2.pause().await.unwrap() } else { c2.resume().await.unwrap() }
+//!             delay_for(dur).await;
 //!         }
 //!     });
 //!
 //!     // receive incoming notifications
-//!     for notification in notifications {
+//!     while let Some(notification) = notifications.next().await {
 //!         println!("{:?}", notification)
 //!     }
 //! }
@@ -113,15 +124,19 @@
 
 #[macro_use]
 extern crate log;
+#[macro_use]
+extern crate rental;
 
 pub mod client;
 pub mod codec;
 pub mod error;
 pub mod mqttoptions;
 
-pub use crate::client::{MqttClient, Notification};
-pub use crate::mqttoptions::{MqttOptions, Proxy, ReconnectOptions, SecurityOptions};
-pub use crate::error::{ConnectError, ClientError};
+pub use crate::{
+    client::{MqttClient, Notification},
+    error::{ClientError, ConnectError},
+    mqttoptions::{MqttOptions, Proxy, ReconnectOptions, SecurityOptions},
+};
 pub use crossbeam_channel::Receiver;
 #[doc(hidden)]
 pub use mqtt311::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,6 +137,6 @@ pub use crate::{
     error::{ClientError, ConnectError},
     mqttoptions::{MqttOptions, Proxy, ReconnectOptions, SecurityOptions},
 };
-pub use crossbeam_channel::Receiver;
+pub use futures::channel::mpsc::Receiver;
 #[doc(hidden)]
 pub use mqtt311::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 //! * Provides several reconnection options to automate reconnections
 //! * All the network requests are done using channels and bad networks can
 //!   be detected through back pressure
-//! * Incoming notifications are delivered to the user through crossbeam channel
+//! * Incoming notifications are delivered to the user through a `futures:channel::mpsc` channel
 //!   which provides a flexible `select!` macro
 //! * Clone the client to access mqtt eventloop from multiple threads
 //! * Dynamically start and stop the network eventloop (Useful when you want the other network services to have more bandwidth)
@@ -41,7 +41,7 @@
 //! ```
 //!
 //!
-//! ## Select on incoming notifications using crossbeam select!
+//! ## Select on incoming notifications using select!
 //! ```no_run
 //! use futures::{channel::oneshot, select, FutureExt, StreamExt};
 //! use rumqtt::{MqttClient, MqttOptions, QoS};

--- a/src/mqttoptions.rs
+++ b/src/mqttoptions.rs
@@ -158,7 +158,7 @@ impl MqttOptions {
     }
 
     pub fn set_connection_timeout(mut self, secs: u16) -> Self {
-        self.connection_timeout =  Duration::from_secs(u64::from(secs));
+        self.connection_timeout = Duration::from_secs(u64::from(secs));
         self
     }
 


### PR DESCRIPTION
Hoo boy. There's lots of changes here. I think things should be working, and I'll be testing on the corpus of code we've built on `rumqtt` at Vivint, but I'm definitely no guru with `async`/`await` or `rumqtt`'s codebase.

Let me know if there are any questions or concerns. It's my job right now to get this upstreamed if possible, so I'll do my best to resolve them quickly!

This PR has a soft dependency on https://github.com/tekjar/mqtt311/pull/2, which is intended to consolidate the dependency tree.